### PR TITLE
Use vrtk_link instead of base_link

### DIFF
--- a/fixposition_driver_ros2/src/data_to_ros2.cpp
+++ b/fixposition_driver_ros2/src/data_to_ros2.cpp
@@ -147,7 +147,7 @@ void PublishFpaOdometryDataImu(const fpa::FpaOdomenuPayload& payload, bool nav2_
         }
         sensor_msgs::msg::Imu msg;
         msg.header.stamp = ros2::utils::ConvTime(FpaGpsTimeToTime(payload.gps_time));
-        msg.header.frame_id = nav2_mode_ ? "base_link" : ODOMETRY_FRAME_ID;
+        msg.header.frame_id = nav2_mode_ ? "vrtk_link" : ODOMETRY_FRAME_ID;
 
         // Orientation quaternion
         const Eigen::Quaterniond quat = {payload.orientation.values[0], payload.orientation.values[1],
@@ -218,7 +218,7 @@ void PublishFpaOdometryDataNavSatFix(const fpa::FpaOdometryPayload& payload, boo
         sensor_msgs::msg::NavSatFix msg;
         msg.header.stamp = ros2::utils::ConvTime(FpaGpsTimeToTime(payload.gps_time));
         if (nav2_mode_) {
-            msg.header.frame_id = "base_link";
+            msg.header.frame_id = "vrtk_link";
         } else {
             msg.header.frame_id = ODOMETRY_CHILD_FRAME_ID;
         }

--- a/fixposition_driver_ros2/src/fixposition_driver_node.cpp
+++ b/fixposition_driver_ros2/src/fixposition_driver_node.cpp
@@ -727,7 +727,7 @@ void FixpositionDriverNode::PublishNav2Tf() {
     geometry_msgs::msg::TransformStamped tf_odom_base;
     tf_odom_base.header.stamp = tfs_.enu0_poi_->header.stamp;
     tf_odom_base.header.frame_id = "odom";
-    tf_odom_base.child_frame_id = "base_link";
+    tf_odom_base.child_frame_id = "vrtk_link";
     tf_odom_base.transform = tf2::toMsg(tf_ENU0POISH);
     // tf_br_->sendTransform(tf_odom_base);
 


### PR DESCRIPTION
Switch back to `vrtk_link` and remove output transformation of the Fixpostion sensor.
Instead we will apply the transformation of the sensor data on the robot itself.